### PR TITLE
correct bug for older openstacks

### DIFF
--- a/vim-wrapper-heat/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/JavaStackCore.java
+++ b/vim-wrapper-heat/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/JavaStackCore.java
@@ -1066,7 +1066,7 @@ public class JavaStackCore {
       buildUrl.append(endpoint);
       buildUrl.append(":");
       buildUrl.append(Network.getPORT());
-      buildUrl.append(String.format("/%s/qos/policies?project_id=%s", Network.getVERSION(), this.projectId));
+      buildUrl.append(String.format("/%s/qos/policies?tenant_id=%s", Network.getVERSION(), this.projectId));
 
       // Logger.debug("[JavaStack] Authenticating client...");
       getQosPolicies = new HttpGet(buildUrl.toString());


### PR DESCRIPTION
Solve the error:
"NeutronError":  "Invalid input for operation: 'project_id' is not supported for filtering."